### PR TITLE
Consistent builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ EXTERNALPROJECT_ADD(
 EXTERNALPROJECT_ADD(
   x265
   DEPENDS yasm
-  DOWNLOAD_COMMAND hg clone https://bitbucket.org/multicoreware/x265
+  DOWNLOAD_COMMAND hg clone https://bitbucket.org/multicoreware/x265 && cd x265 && hg checkout 0.9
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND cd build/linux && PATH=$ENV{PATH} cmake -G "Unix Makefiles" -D CMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR} -D ENABLE_CLI:BOOL=OFF -D ENABLE_SHARED:BOOL=OFF ../../source
   BUILD_COMMAND cd build/linux && PATH=$ENV{PATH} make


### PR DESCRIPTION
Hiya! First off thanks a bunch for putting this together - it's been very useful.

Couple additions for you based on some issues I hit, mainly in that x265 master dropped some params from their api in https://patches.videolan.org/patch/4600/ causing the static build to fail when ffmpeg referenced them. To fix this in a more general way I took the opportunity to define some stable versions to build against when pulling from these external repos, hopefully to keep things stable between your updates.

I had to use git hashes as x264 and rtmpdump don't seem to tag releases.
