### PR TITLE
build on alpine linux and static linking with musl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: required
-dist: trusty
-language: C
-script: make
+
+services:
+  - docker
+
+script:
+  - docker build -t sffmpeg .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ EXTERNALPROJECT_ADD(
   GIT_REPOSITORY git://git.videolan.org/x264.git
   UPDATE_COMMAND ""
   PATCH_COMMAND ${CMAKE_SOURCE_DIR}/patches/patch-manager.sh x264
-  CONFIGURE_COMMAND PATH=$ENV{PATH} ./configure --prefix=${CMAKE_BINARY_DIR} --enable-static
+  CONFIGURE_COMMAND PATH=$ENV{PATH} ./configure --prefix=${CMAKE_BINARY_DIR} --enable-static --enable-pic
   BUILD_COMMAND PATH=$ENV{PATH} make
   BUILD_IN_SOURCE 1
 )
@@ -132,7 +132,7 @@ EXTERNALPROJECT_ADD(
   DEPENDS yasm
   URL http://storage.googleapis.com/downloads.webmproject.org/releases/webm/libvpx-1.5.0.tar.bz2
   PATCH_COMMAND ${CMAKE_SOURCE_DIR}/patches/patch-manager.sh libvpx
-  CONFIGURE_COMMAND PATH=$ENV{PATH} ./configure --prefix=${CMAKE_BINARY_DIR} --disable-shared
+  CONFIGURE_COMMAND PATH=$ENV{PATH} ./configure --prefix=${CMAKE_BINARY_DIR} --disable-shared --enable-pic
   BUILD_COMMAND PATH=$ENV{PATH} make
   BUILD_IN_SOURCE 1
 )
@@ -191,7 +191,7 @@ EXTERNALPROJECT_ADD(
   DEPENDS yasm opencore-amr faac fdkaac lame libogg speex libvorbis libtheora opus xvidcore x264 x265 libvpx rtmpdump freetype libass
   URL http://www.ffmpeg.org/releases/ffmpeg-3.1.2.tar.bz2
   PATCH_COMMAND ${CMAKE_SOURCE_DIR}/patches/patch-manager.sh ffmpeg
-  CONFIGURE_COMMAND PATH=$ENV{PATH} PKG_CONFIG_PATH=$ENV{PKG_CONFIG_PATH} ./configure --prefix=${CMAKE_BINARY_DIR} --datadir=${CMAKE_BINARY_DIR}/etc --disable-shared --enable-static --enable-gpl --enable-version3 --enable-nonfree --disable-doc --disable-debug --disable-ffplay --disable-ffserver --disable-outdevs --enable-runtime-cpudetect --enable-memalign-hack --extra-cflags=-I${CMAKE_BINARY_DIR}/include\ --static --extra-ldflags=-L${CMAKE_BINARY_DIR}/lib --extra-libs=-lstdc++\ -lexpat\ -ldl --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libfaac --enable-libfdk-aac --enable-libmp3lame --enable-libspeex --enable-libtheora --enable-libvorbis --enable-libx264 --enable-libx265 --enable-libxvid --enable-libvpx --enable-libopus --enable-librtmp --enable-libfreetype --enable-libass
+  CONFIGURE_COMMAND PATH=$ENV{PATH} PKG_CONFIG_PATH=$ENV{PKG_CONFIG_PATH} ./configure --prefix=${CMAKE_BINARY_DIR} --datadir=${CMAKE_BINARY_DIR}/etc --disable-shared --enable-static --enable-gpl --enable-version3 --enable-nonfree --disable-doc --disable-debug --disable-ffplay --disable-ffserver --disable-outdevs --enable-runtime-cpudetect --enable-memalign-hack --extra-cflags=-I${CMAKE_BINARY_DIR}/include\ --static --extra-ldflags=-L${CMAKE_BINARY_DIR}/lib --extra-ldflags="-static" --extra-libs=-lstdc++\ -lexpat\ -ldl --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libfaac --enable-libfdk-aac --enable-libmp3lame --enable-libspeex --enable-libtheora --enable-libvorbis --enable-libx264 --enable-libx265 --enable-libxvid --enable-libvpx --enable-libopus --enable-librtmp --enable-libfreetype --enable-libass
   BUILD_COMMAND PATH=$ENV{PATH} make
   BUILD_IN_SOURCE 1
 )

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:latest
+RUN apk add --no-cache build-base cmake autoconf libtool pkgconf git mercurial file linux-headers
+COPY . /sffmpeg
+WORKDIR /sffmpeg
+RUN ls -R && make

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 sffmpeg:
 	@mkdir -p build && \
 	cd build && \
-	cmake -DCMAKE_BUILD_TYPE=Release .. && \
+	cmake -j`cat /proc/cpuinfo|grep ^processor|wc -l` -DCMAKE_BUILD_TYPE=Release .. && \
 	make
 
 distclean:

--- a/patches/rtmpdump/0001-prefix.patch
+++ b/patches/rtmpdump/0001-prefix.patch
@@ -6,8 +6,8 @@
 -prefix=/usr/local
 +prefix=$(PREFIX)
 
- CC=$(CROSS_COMPILE)gcc
- LD=$(CROSS_COMPILE)ld
+ incdir=$(prefix)/include/librtmp
+ bindir=$(prefix)/bin
 
 --- a/Makefile
 +++ b/Makefile


### PR DESCRIPTION
The binary work on alpine and ubuntu, no reason for the binary to not work on other linux distributions, everything is staticaly linked.

```
➜  sffmpeg git:(master) ✗ ldd ./bin/ffmpeg 
	not a dynamic executable
➜  sffmpeg git:(master) ✗ file ./bin/ffmpeg 
./bin/ffmpeg: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```
```
➜  sffmpeg git:(master) ✗ uname -a
Linux linux-desktop 4.4.0-45-generic #66-Ubuntu SMP Wed Oct 19 14:12:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
➜  sffmpeg git:(master) ✗ ./bin/ffmpeg -version
ffmpeg version 3.1.2 Copyright (c) 2000-2016 the FFmpeg developers
built with gcc 5.3.0 (Alpine 5.3.0)
configuration: --prefix=/sffmpeg/build --datadir=/sffmpeg/build/etc --disable-shared --enable-static --enable-gpl --enable-version3 --enable-nonfree --disable-doc --disable-debug --disable-ffplay --disable-ffserver --disable-outdevs --enable-runtime-cpudetect --enable-memalign-hack --extra-cflags='-I/sffmpeg/build/include --static' --extra-ldflags=-L/sffmpeg/build/lib --extra-ldflags='"-static"' --extra-libs='-lstdc++ -lexpat -ldl' --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libfaac --enable-libfdk-aac --enable-libmp3lame --enable-libspeex --enable-libtheora --enable-libvorbis --enable-libx264 --enable-libx265 --enable-libxvid --enable-libvpx --enable-libopus --enable-librtmp --enable-libfreetype --enable-libass
libavutil      55. 28.100 / 55. 28.100
libavcodec     57. 48.101 / 57. 48.101
libavformat    57. 41.100 / 57. 41.100
libavdevice    57.  0.101 / 57.  0.101
libavfilter     6. 47.100 /  6. 47.100
libswscale      4.  1.100 /  4.  1.100
libswresample   2.  1.100 /  2.  1.100
libpostproc    54.  0.100 / 54.  0.100
```

http://www.etalabs.net/compare_libcs.html